### PR TITLE
coverage_to_regions.py should take ref.fa.fai

### DIFF
--- a/scripts/freebayes-parallel
+++ b/scripts/freebayes-parallel
@@ -19,7 +19,7 @@ then
     echo "Generate regions that are equal in terms of data content, and thus have lower variance"
     echo "in runtime.  This will yield better resource utilization."
     echo
-    echo "    bamtools coverage -in aln.bam | coverage_to_regions.py ref.fa 500 >ref.fa.500.regions"
+    echo "    bamtools coverage -in aln.bam | coverage_to_regions.py ref.fa.fai 500 >ref.fa.500.regions"
     echo "    freebayes-parallel ref.fa.500.regions 36 -f ref.fa aln.bam >out.vcf"
     echo
     exit


### PR DESCRIPTION
`freebayes-parallel`'s command-line help erroneously says that `coverage_to_regions.py` should take the `ref.fa` as input, when it really wants the fasta's index (i.e. `ref.fa.fai`as in the other examples).  The default command-line help for coverage_to_regions.py reads in part:
`coverage_to_regions.py  fasta_index num_regions >regions.bed`