### PR TITLE
WIP: implement genotyping timeout

### DIFF
--- a/src/Genotype.cpp
+++ b/src/Genotype.cpp
@@ -1,6 +1,7 @@
 #include "Genotype.h"
 #include "multichoose.h"
 #include "multipermute.h"
+#include <ctime>
 
 
 vector<Allele*> Genotype::uniqueAlleles(void) {
@@ -1143,6 +1144,11 @@ convergentGenotypeComboSearch(
     // set best position, which is updated during the EM step
     GenotypeCombo bestCombo = comboKing;
 
+    // setup timeout
+    int timeoutSeconds = 120;
+    std::time_t start = std::time(0);
+    std::time_t stop = start + timeoutSeconds;
+
     int i = 0;
     for (; i < maxiterations; ++i) {
 
@@ -1238,6 +1244,10 @@ convergentGenotypeComboSearch(
             bestCombo = combos.front();
         }
 
+        if (std::time(0) > stop) {
+            //cerr << "reached timeout" << endl;
+            break;
+        }
     }
 
     //cout << i << " iterations" << "\t" << variantSampleDataLikelihoods.size() << " varying samples"


### PR DESCRIPTION
Hi @ekg 

Here I have implemented (WIP) a time-out for `convergentGenotypeComboSearch`. Some background:   
Often with our tetraploid potato data, FreeBayes takes very very long to genotype certain positions. And often it is fine to skip that variant or have it with a lower quality. 

After quite some debugging (I am new to FreeBayes' code and c++, I work most of my time with Python), it seems FreeBayes spends most of its time in `src/Genotype.cpp : convergentGenotypeComboSearch`. 

To give you an example, I ran FreeBayes with 725 samples:

```sh
freebayes --fasta /path/to/reference.fasta --bam-list cram-files.fofn.txt \
  --cnv-map sample-ploidy.txt --haplotype-length -1 --debug \
  1> >( ts -i '%.s' > ${out}.vcf ) \
  2> >( ts -i '%.s' > ${out}.log )
# ts is part of https://joeyh.name/code/moreutils/
```

The (trimmed) output of v1.3.1:

```
            #CHROM      POS       ID  REF    ALT          QUAL         FILTER  INFO
35.399610   ST4.03ch01  45000692  .   A      G            1.63167e-08  .       DP=27551;GTI=19;ODDS=19.4061
5.105209    ST4.03ch01  45000694  .   A      G            1.98004e-05  .       DP=26487;GTI=39;ODDS=12.3015
9.284241    ST4.03ch01  45000702  .   T      C            2556.23      .       DP=25548;GTI=226;ODDS=588.593
175.726642  ST4.03ch01  45000704  .   TAAGT  TAAGC,TAGGT  105633       .       DP=27517;GTI=320;ODDS=0.112092
244.409537  ST4.03ch01  45000709  .   G      C,T          541828       .       DP=28336;GTI=288;ODDS=0.0213734
7.888341    ST4.03ch01  45000714  .   T      C            381.233      .       DP=26687;GTI=144;ODDS=87.7821
5.578086    ST4.03ch01  45000716  .   G      A            6.77542e-05  .       DP=28929;GTI=40;ODDS=11.0682
```

And with the timeout (120 sec) addition:

```
            #CHROM      POS       ID  REF    ALT          QUAL         FILTER  INFO
34.998759   ST4.03ch01  45000692  .   A      G            1.63167e-08  .       DP=27551;GTI=19;ODDS=19.4061
5.250749    ST4.03ch01  45000694  .   A      G            1.98004e-05  .       DP=26487;GTI=39;ODDS=12.3015
9.434088    ST4.03ch01  45000702  .   T      C            2556.23      .       DP=25548;GTI=226;ODDS=588.593
125.628012  ST4.03ch01  45000704  .   TAAGT  TAAGC,TAGGT  94242        .       DP=27517;GTI=194;ODDS=21700
126.085798  ST4.03ch01  45000709  .   G      C,T          540213       .       DP=28336;GTI=151;ODDS=56898.9
8.112536    ST4.03ch01  45000714  .   T      C            381.233      .       DP=26687;GTI=144;ODDS=87.7821
5.950067    ST4.03ch01  45000716  .   G      A            6.77542e-05  .       DP=28929;GTI=40;ODDS=11.0682
```

As you can see, only the variants that take very long are affected. The number of iterations `GTI` dropped a lot while the `ODDS` increase a lot. Not sure whether that's a bad thing or not? The `QUAL` did not decrease that much (in these cases). All other (removed) measures are not affected. Sometimes extra alleles are included.

Just lowering the iterations with the `-B/--genotyping-max-iterations` option affects all variants requiring more iterations and that is not always related to the time spend as can be seen on position 45000702 which ran 226 iterations in 9 seconds. (I have many more examples with a scatter plot if you like).

For now I hardcoded 120 seconds in `Genotype.cpp`, but this can be parameterized as `--genotyping-timeout`. 

Is the location of the `break` right? At this location during the loop, it acts the same as if `maxiterations` was reached before convergence. 

What do you think? Thanks for your time.