### PR TITLE
Fix: integer fields QA and QR are printed as floats in GVCF

### DIFF
--- a/src/ResultData.cpp
+++ b/src/ResultData.cpp
@@ -714,9 +714,9 @@ vcflib::Variant& Results::gvcf(
 	    
         sampleOutput["DP"].push_back(convert((nc.refCount+nc.altCount) / numSites));
         sampleOutput["MIN_DP"].push_back(convert(minDepth));
-        sampleOutput["QR"].push_back(convert(ln2phred(nc.reflnQ)));
+        sampleOutput["QR"].push_back(convert(llrintl(ln2phred(nc.reflnQ))));
 	sampleOutput["RO"].push_back(convert((nc.refCount/numSites)));
-        sampleOutput["QA"].push_back(convert(ln2phred(nc.altlnQ)));
+        sampleOutput["QA"].push_back(convert(llrintl(ln2phred(nc.altlnQ))));
 	sampleOutput["AO"].push_back(convert((nc.altCount/numSites)));
     }
 


### PR DESCRIPTION
When making a GVCF file, the QA and QR fields are printed as floating point numbers, despite being labeled as integers in the VCF header.

This doesn't show up unless calling high depth data, where the values will be high enough to be printed in scientific notation. In that case, the VCF can't be parsed by many (most?) tools, including VCF validator.

This fixes issues #557 and #558.