### PR TITLE
tweaks to improve performance on long reads

### DIFF
--- a/src/AlleleParser.h
+++ b/src/AlleleParser.h
@@ -176,17 +176,18 @@ public:
     bool allowedHaplotypeBasisAllele(long int pos, string& ref, string& alt);
 
     Allele makeAllele(RegisteredAlignment& ra,
-		      AlleleType type,
-		      long int pos,
-		      int length,
-		      int basesLeft,
-		      int basesRight,
-		      string& readSequence,
-		      string& sampleName,
-		      BAMALIGN& alignment,
-		      string& sequencingTech,
-		      long double qual,
-		      string& qualstr);
+                      AlleleType type,
+                      long int pos,
+                      long int endpos,
+                      int length,
+                      int basesLeft,
+                      int basesRight,
+                      string& readSequence,
+                      string& sampleName,
+                      BAMALIGN& alignment,
+                      string& sequencingTech,
+                      long double qual,
+                      string& qualstr);
 
 
 


### PR DESCRIPTION
This will ultimately require a much more extensive rewrite of the allele parsing logic.

There are a number of `vector<Allele>` copies that are extremely inefficient for long reads. They are bad enough for short reads that a rewrite is a good idea in general.