### PR TITLE
Bug fix: input allele is too short

### DIFF
--- a/src/AlleleParser.cpp
+++ b/src/AlleleParser.cpp
@@ -3990,10 +3990,9 @@ vector<Allele> AlleleParser::genotypeAlleles(
                     }
                 }
                 if (!alreadyPresent) {
-                    if (allele.position == currentPosition && allele.referenceLength == haplotypeLength) {
+                    if (allele.position <= currentPosition && allele.referenceLength >= haplotypeLength) {
                         resultAlleles.push_back(allele);
                     } else {
-                        assert(currentPosition <= allele.position && haplotypeLength >= allele.referenceLength);
                         string altseq = "";
                         string cigar = "";
                         long int extend_left = allele.position - currentPosition;


### PR DESCRIPTION
I encountered the following problem: if you pass `-@ input.vcf.gz` and input variant is not present in the reads, it may be too short in the output. Here is an example:

Input vcf file contains a single variant:
```
chr2    151598431       .       G       A
```
Output vcf file contains variant
```
chr2    151598431       .       GGC     GCC,A,GGA     0       .       ....;CIGAR=1M1X1M,1X,2M1X;
```
Second alternative allele is the input variant, and instead of `AGC` it is just `A`, additionally, CIGAR is just `1X` instead of `1X2M`.

I fixed the problem, but as I am not that familiar with freebayes code, maybe it is not the fastest/cleanest solution.

I can provide input data, if needed.