### PR TITLE
remove bamtools from the repo

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "bamtools"]
-	path = bamtools
-	url = https://github.com/ekg/bamtools.git
 [submodule "intervaltree"]
 	path = intervaltree
 	url = https://github.com/ekg/intervaltree.git

--- a/meson.build
+++ b/meson.build
@@ -175,8 +175,6 @@ bamleftalign_src = files(
 # Include paths
 incdir = include_directories(
     'src',
-    'bamtools/src/api',
-    'bamtools/src',
     'ttmath',
     )
 


### PR DESCRIPTION
Bamtools is not used in the default build configuration and trying to build with -DHAVE_BAMTOOLS=1 results in errors.

This lead me to believe that it might be better to remove HAVE_BAMTOOLS support altogether, eventually.

The option -DHAVE_BAMTOOLS=1 causes this error:
```../src/AlleleParser.cpp: In member function ‘void AlleleParser::updateAlignmentQueue(long int, std::vector<Allele*>&, bool)’:
../src/AlleleParser.cpp:2023:34: error: ‘class BamTools::BamAlignment’ has no member named ‘SecondaryFlag’
 2023 |             if (currentAlignment.SecondaryFlag()) {
      |                                  ^~~~~~~~~~~~~
```