### PR TITLE
Update fasta_generate_regions.py to work with Snakemake example

### DIFF
--- a/examples/freebayes-env.yaml
+++ b/examples/freebayes-env.yaml
@@ -1,11 +1,7 @@
 channels:
   - bioconda
   - conda-forge
-  - r
 dependencies:
-  - freebayes=1.3.2
+  - freebayes>=1.3.4
   - bcftools=1.11
-  - r-tidyverse=1.2.1
-  - r-data.table=1.12.2
-  - r-glue=1.3.1
   - vcflib=1.0.0

--- a/examples/snakemake-freebayes-parallel.smk
+++ b/examples/snakemake-freebayes-parallel.smk
@@ -1,11 +1,11 @@
 ## A simple example snakemake .smk file for parallelising freebayes
-## Uses a simple R script to split the genome into regions of equal size based on the .fai index
+## Uses a fasta_generate_regions to split the genome into regions of equal size based on the .fai index
 ## As snakemake automatically moves each cpu core to the next genome chunk, this works out faster
 ## than the freebayes-parallel wrapper and allows pooled sample calling. 
 ## This .smk file assumes we have a list of the bam files called bam.list
 ## This .smk file splits the genome by chromosome, which of course, is not necessary.
 ## One will want to edit the paths (for example, the path to bam files)
-import numpy as np 
+
 
 # these parameters should usually be stored in the snakemake configuration file (config.yaml) and accessed e.g. config['ref']
 samples = ['SampleA', 'SampleB', 'SampleC']
@@ -14,7 +14,7 @@ chroms = [1,2,3]
 nchunks = 9
 
 bamlist = "path/to/bam.list"
-chunks = np.arange(1, nchunks)
+chunks = [i for i in range(1,nchunks+1)]
 
 rule GenomeIndex:
     input:
@@ -37,29 +37,30 @@ rule GenerateFreebayesRegions:
     log:
         "logs/GenerateFreebayesRegions.log"
     params:
-        chroms = chroms
+        chroms = chroms,
         chunks = chunks
     conda:
         "../envs/freebayes-env.yaml"
     script:
-        "../scripts/GenerateFreebayesRegions.R" # This is located in the scripts/ directory of freebayes
+        # "../scripts/GenerateFreebayesRegions.R" # This is located in the scripts/ directory of freebayes
+        "../scripts/fasta_generate_regions.py --chunks --bed resources/regions/genome --chromosome {params.chroms} {input.index} {params.chunks}"
 
 
 rule VariantCallingFreebayes:
-	input:
-		bams = expand("resources/alignments/{sample}.bam", sample=samples),
-		index = expand("resources/alignments/{sample}.bam.bai", sample=samples),
-		ref = reference,
-		samples = bamlist,
-		regions = "resources/regions/genome.{chrom}.region.{i}.bed"
-	output:
-		temp("results/variants/vcfs/{chrom}/variants.{i}.vcf")
-	log:
-		"logs/VariantCallingFreebayes/{chrom}.{i}.log"
-	conda:
+    input:
+        bams = expand("resources/alignments/{sample}.bam", sample=samples),
+        index = expand("resources/alignments/{sample}.bam.bai", sample=samples),
+        ref = reference,
+        samples = bamlist,
+        regions = "resources/regions/genome.{chrom}.region.{i}.bed"
+    output:
+        temp("results/variants/vcfs/{chrom}/variants.{i}.vcf")
+    log:
+        "logs/VariantCallingFreebayes/{chrom}.{i}.log"
+    conda:
         "../envs/freebayes-env.yaml"
-	threads:1
-	shell:	"freebayes -f {input.ref} -t {input.regions} -L {input.samples} > {output} 2> {log}"
+    threads:1
+    shell:	"freebayes -f {input.ref} -t {input.regions} -L {input.samples} > {output} 2> {log}"
 
 
 rule ConcatVCFs:

--- a/scripts/fasta_generate_regions.py
+++ b/scripts/fasta_generate_regions.py
@@ -1,29 +1,56 @@
 #!/usr/bin/env python3
 
-import sys
+import argparse
 
-if len(sys.argv) == 1:
-    print("usage: {} <fasta file or index file> <region size>".format(sys.argv[0]))
-    print("generates a list of freebayes/bamtools region specifiers on stdout")
-    print("intended for use in creating cluster jobs")
-    exit(1)
 
-fasta_index_file = sys.argv[1]
-if not fasta_index_file.endswith(".fai"):
-    fasta_index_file = fasta_index_file + ".fai"
+def generate_regions(fasta_index_file, size, chunks=False, chromosomes=None, bed_files=None):
 
-fasta_index_file = open(fasta_index_file)
-region_size = int(sys.argv[2])
+    if not fasta_index_file.endswith(".fai"):
+        fasta_index_file = fasta_index_file + ".fai"
 
-for line in fasta_index_file:
-    fields = line.strip().split("\t")
-    chrom_name = fields[0]
-    chrom_length = int(fields[1])
-    region_start = 0
-    while region_start < chrom_length:
-        start = region_start
-        end = region_start + region_size
-        if end > chrom_length:
-            end = chrom_length
-        print(chrom_name + ":" + str(region_start) + "-" + str(end))
-        region_start = end
+    with open(fasta_index_file, "r") as fasta_index:
+        for line in fasta_index:
+            fields = line.strip().split("\t")
+            chrom_name = fields[0]
+            chrom_length = int(fields[1])
+            if chromosomes is not None and chrom_name not in chromosomes:
+                continue
+            region_start = 0
+            if chunks is True:
+                region_size = round(chrom_length / size)  # have to make sure this works
+            else:
+                region_size = size
+            while region_start < chrom_length:
+                region_end = region_start + region_size
+                if region_end > chrom_length:
+                    region_end = chrom_length
+                start = str(region_start)
+                end = str(region_end)
+                if bed_files is not None:
+                    region = str(round(region_end / region_size))
+                    file_path = f"{bed_files}.{chrom_name}.region.{region}.bed"
+                    with open(file_path, "w") as f:
+                        f.write("\t".join([chrom_name, start, end]))
+                else:
+                    print(f"{chrom_name}:{start}-{end}")
+                region_start = region_end
+
+
+if __name__ == "__main__":
+
+    parser = argparse.ArgumentParser(description="Generates a list of freebayes/bamtools region specifiers. Intended "
+                                                 "for parallelization or creating cluster jobs.")
+
+    parser.add_argument("--chunks", action="store_true",
+                        help="Split the fasta into N chunks rather than into N length pieces")
+    parser.add_argument("--chromosomes", nargs="+", default=None,
+                        help="List of chromosomes to create chunks for")
+    parser.add_argument("--bed", metavar="base name", type=str,
+                        help="Write chunks to individual bed files (for Snakemake) instead of stdout.")
+    parser.add_argument("fai", metavar="<fasta or fai file>",
+                        help="The fasta file to split. Must be indexed.")
+    parser.add_argument("region_size", metavar="<N>", type=int,
+                        help="Region size")
+
+    args = parser.parse_args()
+    generate_regions(args.fai, args.region_size, chunks=args.chunks, chromosomes=args.chromosomes, bed_files=args.bed)


### PR DESCRIPTION
Update the fasta_generate_regions.py to allow for splitting each chromosome in
the fasta into N equal chunks, as well as N size chunks. Also allows output to
bedfiles for use with the Snakemake example provided by sanjaynagi. With
default options, it still works with freebayes-parallel. Only uses Python
standard library.