### PR TITLE
Build option to skip system dependencies

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -16,10 +16,17 @@ zlib_dep = dependency('zlib')
 lzma_dep = dependency('liblzma')
 thread_dep = dependency('threads')
 
-htslib_dep = dependency('htslib', required : false)
-tabixpp_dep = cc.find_library('tabixpp', required : false)
-vcflib_dep = dependency('libvcflib', required : false)
-seqlib_dep = dependency('libseqlib', required : false)
+if get_option('prefer_system_deps')
+  htslib_dep = dependency('htslib', required : false)
+  tabixpp_dep = cc.find_library('tabixpp', required : false)
+  vcflib_dep = dependency('libvcflib', required : false)
+  seqlib_dep = dependency('libseqlib', required : false)
+else
+  htslib_dep = dependency('', required : false)
+  tabixpp_dep = dependency('', required : false)
+  vcflib_dep = dependency('', required : false)
+  seqlib_dep = dependency('', required : false)
+endif
 
 # for setting a warning_level on the external code in custom_* targets below
 warn_quiet = ['warning_level=0']

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,1 @@
+option('prefer_system_deps', type : 'boolean', value : true)


### PR DESCRIPTION
1. Adds option to force use of submodule dependencies over system libraries. Forcing the use of the submodules should help in cases where there are all sorts of library versions in the user's search path (see #691).

2. Removes the bin/ folder that is not used anymore but has been mentioned in some support requests. (https://github.com/freebayes/freebayes/issues/688, https://groups.google.com/g/freebayes/c/metaBvKRkos)